### PR TITLE
Update Java 11 -> 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'zulu' # Alternative distribution options are available.
       - name: Cache SonarCloud packages
         uses: actions/cache@v3

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>MySurvey</name>
     <description>MySurvey</description>
     <properties>
-        <java.version>11</java.version>
+        <java.version>21</java.version>
         <jacoco.version>0.8.7</jacoco.version>
         <sonar.organization>vaz8u</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>


### PR DESCRIPTION
Pour config 
- Télécharger Java 21 azul
- Le mettre en sdk du projet et dans la build

> Si ça ne marche pas, passer par Java 16 azul, compiler, puis passer à Java 21 azul, si ça marche toujours pas, refaire la manip en supprimant le dossier target à chaque étapes